### PR TITLE
Update to Zig 0.14

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -73,7 +73,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    const lib_module = &lib.root_module;
+    const lib_module = lib.root_module;
 
     _ = b.addModule("zigplotlib", .{
         .root_source_file = b.path("src/root.zig"),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,8 @@
 .{
-    .name = "zigplotlib",
+    .name = .zigplotlib,
     .version = "0.1.4",
-    .minimum_zig_version = "0.13.0",
+    .fingerprint = 0x1220c9f9d7b4cb25,
+    .minimum_zig_version = "0.14.0",
     .dependencies = .{},
 
     .paths = .{

--- a/example/scatter.zig
+++ b/example/scatter.zig
@@ -14,7 +14,7 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
     
-    var xoshiro = std.rand.Xoshiro256.init(100);
+    var xoshiro = std.Random.Xoshiro256.init(100);
     var rand = xoshiro.random();
 
     var x: [28]f32 = undefined;

--- a/src/core/intf.zig
+++ b/src/core/intf.zig
@@ -13,32 +13,32 @@ fn checkFunctionImplementation(
     const Function =  Field.type;
     const function = @typeInfo(Function);
 
-    if (function != .Fn) @compileError("The Interface should only contains functions (as field)");
-    if (function.Fn.is_generic) @compileError("Generic functions are not supported!");
-    if (function.Fn.is_var_args) @compileError("Variadic functions are not supported!");
+    if (function != .@"fn") @compileError("The Interface should only contains functions (as field)");
+    if (function.@"fn".is_generic) @compileError("Generic functions are not supported!");
+    if (function.@"fn".is_var_args) @compileError("Variadic functions are not supported!");
 
     const actual = @typeInfo(Actual);
-    if (actual != .Struct) @compileError(comptimePrint("'{s}' should be a struct that implements '{s}'", .{
+    if (actual != .@"struct") @compileError(comptimePrint("'{s}' should be a struct that implements '{s}'", .{
         @typeName(Actual),
         @typeName(Interface),
     }));
 
-    inline for (actual.Struct.decls) |decl| {
+    inline for (actual.@"struct".decls) |decl| {
         if (comptime std.mem.eql(u8, decl.name, Field.name)) {
             const decl_ = @field(Actual, decl.name);
             const Decl = @TypeOf(decl_);
             const decl_info = @typeInfo(Decl);
 
-            if (decl_info != .Fn) @compileError(comptimePrint("Invalid Type for '{s}', should be {s}", .{
+            if (decl_info != .@"fn") @compileError(comptimePrint("Invalid Type for '{s}', should be {s}", .{
                 Field.name,
                 @typeName(Function),
             }));
-            if (decl_info.Fn.is_generic or decl_info.Fn.is_var_args) @compileError(comptimePrint("Invalid Type for '{s}', should be {s}", .{
+            if (decl_info.@"fn".is_generic or decl_info.@"fn".is_var_args) @compileError(comptimePrint("Invalid Type for '{s}', should be {s}", .{
                 Field.name,
                 @typeName(Function),
             }));
 
-            inline for (function.Fn.params, decl_info.Fn.params, 0..) |expected_param, actual_param, i| {
+            inline for (function.@"fn".params, decl_info.@"fn".params, 0..) |expected_param, actual_param, i| {
                 if (i == 0) {
                     if (expected_param.type == *const anyopaque) {
                         if (actual_param.type != *const Actual) @compileError(comptimePrint("'self' (the 1st argument) should be of type '*const {s}'\nDefinition for '{s}':\n{s}", .{
@@ -66,7 +66,7 @@ fn checkFunctionImplementation(
                 }));
             }
 
-            if (function.Fn.return_type != decl_info.Fn.return_type) @compileError(comptimePrint("Invalid return type for '{s}', should be {s}\nDefinition for '{s}':\n{s}", .{
+            if (function.@"fn".return_type != decl_info.@"fn".return_type) @compileError(comptimePrint("Invalid return type for '{s}', should be {s}\nDefinition for '{s}':\n{s}", .{
                 Field.name,
                 @typeName(Function),
                 Field.name,
@@ -93,9 +93,9 @@ pub fn ensureImplement(
 ) void {
     const interface = @typeInfo(Interface);
 
-    if (interface != .Struct) @compileError("The Interface should be a struct containing the functions as fields");
+    if (interface != .@"struct") @compileError("The Interface should be a struct containing the functions as fields");
 
-    inline for (interface.Struct.fields) |field| {
+    inline for (interface.@"struct".fields) |field| {
         checkFunctionImplementation(Interface, field, Actual);
     }
 }

--- a/src/util/range.zig
+++ b/src/util/range.zig
@@ -18,7 +18,7 @@ pub fn Range(comptime T: type) type {
 
         /// Initialize a range with the minimum and maximum values set to the same value. [-∞; ∞]
         pub fn inf() Self {
-            if (@typeInfo(T) != .Float) @compileError("Only floating point types can have infinite ranges");
+            if (@typeInfo(T) != .@"float") @compileError("Only floating point types can have infinite ranges");
 
             return Self{
                 .min = -std.math.inf(T),
@@ -28,7 +28,7 @@ pub fn Range(comptime T: type) type {
 
         /// Initialize a range with the minimum and maximum values set to the same value. [∞; -∞]
         pub fn invInf() Self {
-            if (@typeInfo(T) != .Float) @compileError("Only floating point types can have infinite ranges");
+            if (@typeInfo(T) != .@"float") @compileError("Only floating point types can have infinite ranges");
 
             return Self{
                 .min = std.math.inf(T),


### PR DESCRIPTION
Fix some files to build with Zig 0.14 (but can't be built with Zig 0.13 anymore)

There were some syntax errors that I didn't really understand but looking at past versions of the official documentation it seems that the syntax just changed:

Zig 0.13:
https://ziglang.org/documentation/0.13.0/#toc-Inline-Switch-Prongs
> const fields = @typeInfo(T).Struct.fields;

Zig 0.14:
https://ziglang.org/documentation/0.14.0/#Inline-Switch-Prongs
> const fields = @typeInfo(T).@"struct".fields;